### PR TITLE
update npm package clf-date to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino-toke",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Transform Pino HTTP log messages with a format string",
   "main": "index.js",
   "bin": {
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "basic-auth": "^2.0.1",
-    "clf-date": "0.1.0",
+    "clf-date": "0.2.0",
     "minimist": "^1.2.0",
     "readable-stream": "^3.6.0",
     "sonic-boom": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "license": "MIT",
   "devDependencies": {
     "standard": "^14.0.0",
-    "tap": "^14.0.0"
+    "tap": "^14.0.0",
+    "timeshift-js": "^1.1.1"
   },
   "dependencies": {
     "basic-auth": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pino-toke",
-  "version": "1.0.5",
+  "version": "1.0.4",
   "description": "Transform Pino HTTP log messages with a format string",
   "main": "index.js",
   "bin": {

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@
 var toke = require('../')
 var through = require('through2')
 var test = require('tap').test
+var TimeShift = require('timeshift-js')
 
 var log = '{"pid":13961,"hostname":"MacBook-Pro-4","level":30,"time":1469122492244,"msg":"request completed","res":{"statusCode":200,"headers":{"content-type": "application/json; charset=utf-8","cache-control":"no-cache","vary":"accept-encoding","content-encoding":"gzip","date":"Thu, 21 Jul 2016 17:34:52 GMT","connection":"close","transfer-encoding":"chunked"}},"responseTime":17,"req":{"id":8,"method":"GET","url":"/api/activity/component","headers":{"host":"localhost:20000","connection":"keep-alive","cache-control":"max-age=0","authorization":"Basic QWxhZGRpbjpPcGVuU2VzYW1l","accept":"application/json","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36","referer":"http://localhost:20000/","accept-encoding":"gzip, deflate, sdch","accept-language":"en-US,en;q=0.8,de;q=0.6","cookie":"_ga=GA1.1.204420087.1444842476"},"remoteAddress":"127.0.0.1","remotePort":61543},"v":1}\n'
 
@@ -124,13 +125,26 @@ test(':date[iso]', function (t) {
 })
 
 test(':date[clf]', function (t) {
-  /* eslint no-extend-native: 0 */
-  var getTimezoneOffset = Date.prototype.getTimezoneOffset
-  Date.prototype.getTimezoneOffset = function () { return 0 }
+  /* eslint no-global-assign: 0 */
+  Date = TimeShift.Date
+  TimeShift.setTimezoneOffset(0)
   var expected = '21/Jul/2016:17:34:52 +0000\n'
   var logger = toke(':date[clf]', through(function (line) {
     t.is(line.toString(), expected)
-    Date.prototype.getTimezoneOffset = getTimezoneOffset
+    Date = TimeShift.OriginalDate
+    t.end()
+  }))
+  logger.write(log)
+})
+
+test(':date[clf] (JST)', function (t) {
+  /* eslint no-global-assign: 0 */
+  Date = TimeShift.Date
+  TimeShift.setTimezoneOffset(-540)
+  var expected = '22/Jul/2016:02:34:52 +0900\n'
+  var logger = toke(':date[clf]', through(function (line) {
+    t.is(line.toString(), expected)
+    Date = TimeShift.OriginalDate
     t.end()
   }))
   logger.write(log)


### PR DESCRIPTION
Closes #2 

This PR resolve issue #2.
I confirmed clf-date 0.2.0 output correct CLF format.

```bash
$ npm list --global pino-toke
/home/vagrant/.nodebrew/node/v12.16.3/lib
└── pino-toke@1.0.5 

$ node pino-toke-test.js | pino-toke :date[clf]
04/May/2020:16:22:24 +0900
^C
$ LANG=en_US date
Mon May  4 16:22:33 JST 2020
```
