### PR TITLE
chore!: drop support for node 12; add support for node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2.3.4
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
BREAKING CHANGE: Drops support for EOL node 12; adds support for node 18