### PR TITLE
Modernize code and drop old Node versions

### DIFF
--- a/.borp.yaml
+++ b/.borp.yaml
@@ -1,0 +1,7 @@
+files:
+  - 'test/*.test.js'
+
+coverage:
+  lines: 95
+  branches: 93
+  statements: 95

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node-version: [14, 16, 18]
+        node-version: [20, 22, 24]
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.4.0
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install

--- a/cmd.js
+++ b/cmd.js
@@ -34,7 +34,7 @@ else if (args.a === 2) ancillary = process.stderr
 else if (args.a !== undefined) ancillary = SonicBoom({ dest: parseInt(args.a) })
 
 if (args.k) {
-  format = { format: format, keep: true }
+  format = { format, keep: true }
 }
 
 process.stdin.pipe(toke(format, destination, ancillary))

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = require('neostandard')({})

--- a/lib/transport.js
+++ b/lib/transport.js
@@ -7,7 +7,6 @@ const tokens = require('./tokens')
 
 module.exports = pinoTransport
 
-/* istanbul ignore next */
 function pinoTransport (options) {
   if (!options || !options.format) {
     throw new Error('Missing format option')

--- a/package.json
+++ b/package.json
@@ -7,26 +7,28 @@
     "pino-toke": "./cmd.js"
   },
   "scripts": {
-    "lint:fix": "standard --fix",
-    "test": "standard && tap --timeout=0 test/*.js",
-    "ci": "standard && tap --timeout=0 --cov --coverage-report=lcov test/*.js"
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "test": "npm run lint && borp",
+    "ci": "npm run lint && borp --coverage --check-coverage --reporter=lcov"
   },
   "author": "David Mark Clements",
   "license": "MIT",
   "devDependencies": {
-    "pino": "^7.0.0-rc.6",
-    "standard": "^16.0.3",
-    "tap": "^15.0.9",
+    "borp": "^1.0.0",
+    "eslint": "^9.39.4",
+    "neostandard": "^0.13.0",
+    "pino": "^10.3.1",
     "timeshift-js": "^1.1.1"
   },
   "dependencies": {
     "basic-auth": "^2.0.1",
-    "clf-date": "0.2.0",
+    "clf-date": "^0.2.1",
     "minimist": "^1.2.0",
-    "pino-abstract-transport": "^0.3.0",
+    "pino-abstract-transport": "^3.0.0",
     "readable-stream": "^3.6.0",
-    "sonic-boom": "^2.2.3",
-    "split2": "^3.1.1",
+    "sonic-boom": "^4.2.1",
+    "split2": "^4.2.0",
     "through2": "^3.0.2"
   },
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,4 @@
-# pino-toke 
-
-[![stability][0]][1]
-[![npm version][2]][3]
-[![CI](https://github.com/pinojs/pino-toke/actions/workflows/ci.yml/badge.svg)](https://github.com/pinojs/pino-toke/actions/workflows/ci.yml)
-[![dependencies freshness][14]][15]
-[![js-standard-style][10]][11]
+# pino-toke
 
 Transform Pino HTTP log messages with a format string
 
@@ -321,17 +315,7 @@ MIT
 * Inspired by the [`morgan`](http://npm.im/morgan) logger
 * Sponsored by [nearForm](http://nearform.com)
 
-
-
-[0]: https://img.shields.io/badge/stability-stable-green.svg?style=flat-square
-[1]: https://nodejs.org/api/documentation.html#documentation_stability_index
-[2]: https://img.shields.io/npm/v/pino-toke.svg?style=flat-square
-[3]: https://npmjs.org/package/pino-toke
 [8]: http://img.shields.io/npm/dm/pino-toke.svg?style=flat-square
 [9]: https://npmjs.org/package/pino-toke
-[10]: https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square
-[11]: https://github.com/feross/standard
 [12]: https://npm.im/debug
 [13]: https://npm.im/github/pinojs/pino
-[14]: https://img.shields.io/librariesio/release/npm/pino-toke
-[15]: https://libraries.io/npm/pino-toke

--- a/test/cmd.test.js
+++ b/test/cmd.test.js
@@ -1,275 +1,275 @@
 'use strict'
 
-const cp = require('child_process')
-const path = require('path')
-const fs = require('fs')
-const test = require('tap').test
+const test = require('node:test')
+const cp = require('node:child_process')
+const path = require('node:path')
+const fs = require('node:fs')
 
 const log = JSON.stringify(require('./fixtures/log-obj.json')) + '\n'
 const cwd = path.resolve(__dirname, '..')
 
-test('-h', function (t) {
+test('-h', function (t, end) {
   const expected = fs.readFileSync(path.join(cwd, 'usage.txt')) + '\n'
   const args = ['-h']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[1] + '', expected)
+  t.assert.equal(result.output[1] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('--help', function (t) {
+test('--help', function (t, end) {
   const expected = fs.readFileSync(path.join(cwd, 'usage.txt')) + '\n'
   const args = ['--help']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[1] + '', expected)
+  t.assert.equal(result.output[1] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('tokens', function (t) {
+test('tokens', function (t, end) {
   const expected = 'MacBook-Pro-4 13961 GET /api/activity/component 200 (17 ms) application/json; charset=utf-8 _ga=GA1.1.204420087.1444842476\n\n'
   const args = [':hostname', ':pid', ':method', ':url', ':status', '(:response-time', 'ms)', ':res[content-type]', ':req[cookie]']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[1] + '', expected)
+  t.assert.equal(result.output[1] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('-d', function (t) {
+test('-d', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-d', '2', ':pid']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[2] + '', expected)
+  t.assert.equal(result.output[2] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('--destination', function (t) {
+test('--destination', function (t, end) {
   const expected = '13961\n\n'
   const args = ['--destination', '2', ':pid']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[2] + '', expected)
+  t.assert.equal(result.output[2] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('--dest', function (t) {
+test('--dest', function (t, end) {
   const expected = '13961\n\n'
   const args = ['--dest', '2', ':pid']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[2] + '', expected)
+  t.assert.equal(result.output[2] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('-d with custom fd', function (t) {
+test('-d with custom fd', function (t, end) {
   const expected = '13961\n'
   const args = ['-d', '3', ':pid']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[3] + '', expected)
+  t.assert.equal(result.output[3] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('-d 1', function (t) {
+test('-d 1', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-d', '1', ':pid']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[1] + '', expected)
+  t.assert.equal(result.output[1] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('-d stderr', function (t) {
+test('-d stderr', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-d', 'stderr', ':pid']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[2] + '', expected)
+  t.assert.equal(result.output[2] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('-d stdout', function (t) {
+test('-d stdout', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-d', 'stdout', ':pid']
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log
   })
 
-  t.is(result.output[1] + '', expected)
+  t.assert.equal(result.output[1] + '', expected)
 
-  t.end()
+  end()
 })
 
-test('-a', function (t) {
+test('-a', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-a', '2', ':pid']
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log + msg
   })
 
-  t.is(result.output[1] + '', expected)
-  t.is(result.output[2] + '', msg)
+  t.assert.equal(result.output[1] + '', expected)
+  t.assert.equal(result.output[2] + '', msg)
 
-  t.end()
+  end()
 })
 
-test('--ancillary', function (t) {
+test('--ancillary', function (t, end) {
   const expected = '13961\n\n'
   const args = ['--ancillary', '2', ':pid']
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log + msg
   })
 
-  t.is(result.output[1] + '', expected)
-  t.is(result.output[2] + '', msg)
+  t.assert.equal(result.output[1] + '', expected)
+  t.assert.equal(result.output[2] + '', msg)
 
-  t.end()
+  end()
 })
 
-test('-a with custom fd', function (t) {
+test('-a with custom fd', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-a', '3', ':pid']
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe', 'pipe'],
     input: log + msg
   })
 
-  t.is(result.output[1] + '', expected)
-  t.is(result.output[3] + '', msg)
+  t.assert.equal(result.output[1] + '', expected)
+  t.assert.equal(result.output[3] + '', msg)
 
-  t.end()
+  end()
 })
 
-test('-a 1 -d 2', function (t) {
+test('-a 1 -d 2', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-a', '1', '-d', '2', ':pid']
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log + msg
   })
 
-  t.is(result.output[2] + '', expected)
-  t.is(result.output[1] + '', msg)
+  t.assert.equal(result.output[2] + '', expected)
+  t.assert.equal(result.output[1] + '', msg)
 
-  t.end()
+  end()
 })
 
-test('-a stderr', function (t) {
+test('-a stderr', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-a', 'stderr', ':pid']
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log + msg
   })
 
-  t.is(result.output[1] + '', expected)
-  t.is(result.output[2] + '', msg)
+  t.assert.equal(result.output[1] + '', expected)
+  t.assert.equal(result.output[2] + '', msg)
 
-  t.end()
+  end()
 })
 
-test('-a stdout -d 2', function (t) {
+test('-a stdout -d 2', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-a', 'stdout', '-d', '2', ':pid']
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log + msg
   })
 
-  t.is(result.output[2] + '', expected)
-  t.is(result.output[1] + '', msg)
+  t.assert.equal(result.output[2] + '', expected)
+  t.assert.equal(result.output[1] + '', msg)
 
-  t.end()
+  end()
 })
 
-test('-a 1 -d 1', function (t) {
+test('-a 1 -d 1', function (t, end) {
   const expected = '13961'
   const args = ['-a', '1', '-d', '1', ':pid']
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log + msg
   })
-  t.is(result.output[1] + '', expected + '\n' + msg + '\n')
+  t.assert.equal(result.output[1] + '', expected + '\n' + msg + '\n')
 
-  t.end()
+  end()
 })
 
-test('-k -a 2', function (t) {
+test('-k -a 2', function (t, end) {
   const expected = '13961\n\n'
   const args = ['-k', '-a', '2', ':pid']
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   const result = cp.spawnSync('node', ['cmd.js'].concat(args), {
-    cwd: cwd,
+    cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     input: log + msg
   })
 
-  t.is(result.output[1] + '', expected)
-  t.is(result.output[2] + '', log + msg)
+  t.assert.equal(result.output[1] + '', expected)
+  t.assert.equal(result.output[2] + '', log + msg)
 
-  t.end()
+  end()
 })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,383 +1,383 @@
 'use strict'
 
-const { toke } = require('../')
+const test = require('node:test')
 const through = require('through2')
-const test = require('tap').test
 const TimeShift = require('timeshift-js')
+const { toke } = require('../')
 
 const log = '{"pid":13961,"hostname":"MacBook-Pro-4","level":30,"time":1469122492244,"msg":"request completed","res":{"statusCode":200,"headers":{"content-type": "application/json; charset=utf-8","cache-control":"no-cache","vary":"accept-encoding","content-encoding":"gzip","date":"Thu, 21 Jul 2016 17:34:52 GMT","connection":"close","transfer-encoding":"chunked"}},"responseTime":17,"req":{"id":8,"method":"GET","url":"/api/activity/component","headers":{"host":"localhost:20000","connection":"keep-alive","cache-control":"max-age=0","authorization":"Basic QWxhZGRpbjpPcGVuU2VzYW1l","accept":"application/json","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36","referer":"http://localhost:20000/","accept-encoding":"gzip, deflate, sdch","accept-language":"en-US,en;q=0.8,de;q=0.6","cookie":"_ga=GA1.1.204420087.1444842476"},"remoteAddress":"127.0.0.1","remotePort":61543},"v":1}\n'
 
-test(':id', function (t) {
+test(':id', function (t, end) {
   const expected = '8\n'
   const logger = toke(':id', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':pid', function (t) {
+test(':pid', function (t, end) {
   const expected = '13961\n'
   const logger = toke(':pid', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':hostname', function (t) {
+test(':hostname', function (t, end) {
   const expected = 'MacBook-Pro-4\n'
   const logger = toke(':hostname', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':level', function (t) {
+test(':level', function (t, end) {
   const expected = '30\n'
   const logger = toke(':level', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':url', function (t) {
+test(':url', function (t, end) {
   const expected = '/api/activity/component\n'
   const logger = toke(':url', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':time', function (t) {
+test(':time', function (t, end) {
   const expected = '1469122492244\n'
   const logger = toke(':time', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':time[ms]', function (t) {
+test(':time[ms]', function (t, end) {
   const expected = '1469122492244\n'
   const logger = toke(':time[ms]', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':time[iso]', function (t) {
+test(':time[iso]', function (t, end) {
   const expected = '17:34:52\n'
   const logger = toke(':time[iso]', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':method', function (t) {
+test(':method', function (t, end) {
   const expected = 'GET\n'
   const logger = toke(':method', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':response-time', function (t) {
+test(':response-time', function (t, end) {
   const expected = '17\n'
   const logger = toke(':response-time', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':date', function (t) {
+test(':date', function (t, end) {
   const expected = 'Thu, 21 Jul 2016 17:34:52 GMT\n'
   const logger = toke(':date', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':date[web]', function (t) {
+test(':date[web]', function (t, end) {
   const expected = 'Thu, 21 Jul 2016 17:34:52 GMT\n'
   const logger = toke(':date', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':date[iso]', function (t) {
+test(':date[iso]', function (t, end) {
   const expected = '2016-07-21T17:34:52.244Z\n'
   const logger = toke(':date[iso]', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':date[clf]', function (t) {
+test(':date[clf]', function (t, end) {
   /* eslint no-global-assign: 0 */
   Date = TimeShift.Date
   TimeShift.setTimezoneOffset(0)
   const expected = '21/Jul/2016:17:34:52 +0000\n'
   const logger = toke(':date[clf]', through(function (line) {
-    t.equal(line.toString(), expected)
+    t.assert.equal(line.toString(), expected)
     Date = TimeShift.OriginalDate
-    t.end()
+    end()
   }))
   logger.write(log)
 })
 
-test(':date[clf] (JST)', function (t) {
-  /* eslint no-global-assign: 0 */
+test(':date[clf] (JST)', function (t, end) {
   Date = TimeShift.Date
   TimeShift.setTimezoneOffset(-540)
   const expected = '22/Jul/2016:02:34:52 +0900\n'
   const logger = toke(':date[clf]', through(function (line) {
-    t.equal(line.toString(), expected)
+    t.assert.equal(line.toString(), expected)
     Date = TimeShift.OriginalDate
-    t.end()
+    end()
   }))
   logger.write(log)
 })
 
-test(':status', function (t) {
+test(':status', function (t, end) {
   const expected = '200\n'
   const logger = toke(':status', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':referrer', function (t) {
+test(':referrer', function (t, end) {
   const expected = 'http://localhost:20000/\n'
   const logger = toke(':referrer', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log.replace('referer', 'referrer'))
 })
 
-test(':referrer (normalizing)', function (t) {
+test(':referrer (normalizing)', function (t, end) {
   const expected = 'http://localhost:20000/\n'
   const logger = toke(':referrer', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':remote-addr', function (t) {
+test(':remote-addr', function (t, end) {
   const expected = '127.0.0.1\n'
   const logger = toke(':remote-addr', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':remote-user', function (t) {
+test(':remote-user', function (t, end) {
   const expected = 'Aladdin\n'
   const logger = toke(':remote-user', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':remote-user without authorization header', function (t) {
+test(':remote-user without authorization header', function (t, end) {
   const expected = '-\n'
   const logger = toke(':remote-user', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write('{"pid":13961,"hostname":"MacBook-Pro-4","level":30,"time":1469122492244,"msg":"request completed","res":{"statusCode":200,"header":"HTTP/1.1 200 OK\\r\\ncontent-type: application/json; charset=utf-8\\r\\ncache-control: no-cache\\r\\nvary: accept-encoding\\r\\ncontent-encoding: gzip\\r\\ndate: Thu, 21 Jul 2016 17:34:52 GMT\\r\\nconnection: close\\r\\ntransfer-encoding: chunked\\r\\n\\r\\n"},"responseTime":17,"req":{"id":8,"method":"GET","url":"/api/activity/component","headers":{"host":"localhost:20000","connection":"keep-alive","cache-control":"max-age=0","accept":"application/json","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36","referer":"http://localhost:20000/","accept-encoding":"gzip, deflate, sdch","accept-language":"en-US,en;q=0.8,de;q=0.6","cookie":"_ga=GA1.1.204420087.1444842476"},"remoteAddress":"127.0.0.1","remotePort":61543},"v":1}\n')
 })
 
-test(':user-agent', function (t) {
+test(':user-agent', function (t, end) {
   const expected = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36\n'
   const logger = toke(':user-agent', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':req[<header>]', function (t) {
+test(':req[<header>]', function (t, end) {
   const expected = 'keep-alive\n'
   const logger = toke(':req[connection]', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':req[<invalid header>]', function (t) {
+test(':req[<invalid header>]', function (t, end) {
   const expected = '-\n'
   const logger = toke(':req[foo]', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':req without header', function (t) {
+test(':req without header', function (t, end) {
   const expected = '-\n'
   const logger = toke(':req', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':res[<header>]', function (t) {
+test(':res[<header>]', function (t, end) {
   const expected = 'application/json; charset=utf-8\n'
   const logger = toke(':res[content-type]', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':res[<invalid header>]', function (t) {
+test(':res[<invalid header>]', function (t, end) {
   const expected = '-\n'
   const logger = toke(':res[foo]', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':res without header', function (t) {
+test(':res without header', function (t, end) {
   const expected = '-\n'
   const logger = toke(':res', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':invalid-token', function (t) {
+test(':invalid-token', function (t, end) {
   const expected = ':invalid-token\n'
   const logger = toke(':invalid-token', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test(':invalid-token[with-arg]', function (t) {
+test(':invalid-token[with-arg]', function (t, end) {
   const expected = ':invalid-token[with-arg]\n'
   const logger = toke(':invalid-token[with-arg]', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test('composition/interpolation', function (t) {
+test('composition/interpolation', function (t, end) {
   const expected = 'MacBook-Pro-4 13961 GET /api/activity/component 200 (17 ms) application/json; charset=utf-8 _ga=GA1.1.204420087.1444842476\n'
   const logger = toke(':hostname :pid :method :url :status (:response-time ms) :res[content-type] :req[cookie]', through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test('outputs newline when stream ends', function (t) {
+test('outputs newline when stream ends', function (t, end) {
   const expected = '\n'
   const stream = through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    process._rawDebug('!!!')
+    t.assert.equal(line.toString(), expected)
+    end()
   })
   toke(':pid', stream).end()
 })
 
-test('outputs error message when error in pipeline', function (t) {
+test('outputs error message when error in pipeline', function (t, end) {
   const expected = 'Premature close\n'
   const stream = through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   })
   toke(':pid', stream)
   stream.destroy()
 })
 
-test('logs to process.stdout by default', function (t) {
+test('logs to process.stdout by default', function (t, end) {
   const expected = '13961\n'
   const logger = toke(':pid')
   const write = process.stdout.write
   process.stdout.write = function (chunk, enc, cb) {
     process.stdout.write = write
-    t.equal(chunk.toString(), expected)
-    t.end()
+    t.assert.equal(chunk.toString(), expected)
+    end()
   }
   logger.write(log)
 })
 
-test('outputs error message when error in pipeline', function (t) {
+test('outputs error message when error in pipeline', function (t, end) {
   const expected = 'Premature close\n'
   const stream = through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   })
   toke(':pid', stream)
   stream.destroy()
 })
 
-test('format as object', function (t) {
+test('format as object', function (t, end) {
   const expected = '13961\n'
   const logger = toke({ format: ':pid' }, through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test('filters non-http messages by default', function (t) {
+test('filters non-http messages by default', function (t, end) {
   const logger = toke(':pid', through(function (line) {
     t.fail()
-    t.end()
+    end()
   }))
   logger.write('{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n')
   setTimeout(function () {
-    t.pass()
-    t.end()
+    t.assert.ok('pass')
+    end()
   }, 100)
 })
 
-test('ancillary: passes non-http messages to alternative stream when specified', function (t) {
+test('ancillary: passes non-http messages to alternative stream when specified', function (t, end) {
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   const logger = toke(':pid', through(), through(function (line) {
-    t.equal(line.toString() + '', msg)
-    t.end()
+    t.assert.equal(line.toString() + '', msg)
+    end()
   }))
   logger.write(msg)
 })
 
-test('keep: passes all messages to alternative stream', function (t) {
+test('keep: passes all messages to alternative stream', function (t, end) {
   const expected = '13961\n'
   const msg = '{"pid":94473,"hostname":"MacBook-Pro-3.home","level":30,"msg":"hello world","time":1459529098958,"v":1}\n'
   let count = 0
   const logger = toke({ format: ':pid', keep: true }, through(function (line, _, cb) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
     cb()
   }), through(function (line, _, cb) {
     count++
 
     if (count === 1) {
-      t.equal(line.toString() + '', msg)
+      t.assert.equal(line.toString() + '', msg)
     }
     cb()
   }))
@@ -386,24 +386,24 @@ test('keep: passes all messages to alternative stream', function (t) {
   logger.write(log)
 })
 
-test('custom function', function (t) {
+test('custom function', function (t, end) {
   const expected = log
   const logger = toke(function (tokens, o) {
     return log
   }, through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })
 
-test('toke.compile', function (t) {
+test('toke.compile', function (t, end) {
   const expected = '13961\n'
   const logger = toke(function (tokens, o) {
     return toke.compile(':pid')(tokens, o)
   }, through(function (line) {
-    t.equal(line.toString(), expected)
-    t.end()
+    t.assert.equal(line.toString(), expected)
+    end()
   }))
   logger.write(log)
 })

--- a/test/transport.test.js
+++ b/test/transport.test.js
@@ -1,18 +1,18 @@
 'use strict'
 
-const t = require('tap')
-const os = require('os')
-const fs = require('fs')
-const { spawnSync } = require('child_process')
-const { join } = require('path')
-const { once } = require('events')
-const { promisify } = require('util')
+const test = require('node:test')
+const os = require('node:os')
+const fs = require('node:fs')
+const { spawnSync } = require('node:child_process')
+const { join } = require('node:path')
+const { once } = require('node:events')
+const { promisify } = require('node:util')
 const pino = require('pino')
 
 const logObj = require('./fixtures/log-obj.json')
 const timeout = promisify(setTimeout)
 
-t.test('tock pino transport test', async t => {
+test('tock pino transport test', async t => {
   const destination = join(
     os.tmpdir(),
     'pino-transport-test.log'
@@ -31,9 +31,9 @@ t.test('tock pino transport test', async t => {
     options
   })
   const log = pino(transport)
-  t.pass('built pino')
+  t.assert.ok('built pino')
   await once(transport, 'ready')
-  t.pass('transport ready ' + destination)
+  t.assert.ok('transport ready ' + destination)
 
   log.info(logObj)
   log.debug(logObj)
@@ -42,24 +42,24 @@ t.test('tock pino transport test', async t => {
   await timeout(1000)
 
   const data = fs.readFileSync(destination, 'utf8')
-  t.equal(data.trim(), logObj.hostname)
+  t.assert.equal(data.trim(), logObj.hostname)
 })
 
-t.test('tock pino transport test stdout', async t => {
+test('tock pino transport test stdout', async t => {
   const result = spawnSync('node', [join(__dirname, 'fixtures', 'log-stdout.js'), '1'], {
     cwd: process.cwd()
   })
-  t.equal(result.output[1].toString().trim(), logObj.hostname)
+  t.assert.equal(result.output[1].toString().trim(), logObj.hostname)
 })
 
-t.test('tock pino transport test stderr', async t => {
+test('tock pino transport test stderr', async t => {
   const result = spawnSync('node', [join(__dirname, 'fixtures', 'log-stdout.js'), '2'], {
     cwd: process.cwd()
   })
-  t.equal(result.output[2].toString().trim(), logObj.hostname)
+  t.assert.equal(result.output[2].toString().trim(), logObj.hostname)
 })
 
-t.test('tock pino transport test', async t => {
+test('tock pino transport test', async t => {
   try {
     const transport = pino.transport({
       target: join(__dirname, '../index.js'),
@@ -67,8 +67,8 @@ t.test('tock pino transport test', async t => {
     })
     pino(transport)
     await once(transport, 'ready')
-    t.fail('should not be ready')
+    t.assert.fail('should not be ready')
   } catch (error) {
-    t.equal(error.message, 'Missing format option')
+    t.assert.equal(error.message, 'Missing format option')
   }
 })


### PR DESCRIPTION
As titled. Note: when either or both of `through2` and `readable-stream` are upgraded tests will not complete. `readable-streams` doesn't have release notes for v4.0.0, so I can't easily check to see what changed there, and `through2` just never posted _any_ release notes. So I'm not going to try and figure it out. I think [the stats](https://npm-stat.com/charts.html?package=pino-toke) on this one are already borderline, and debated simply deprecating and archiving it.